### PR TITLE
Check for name and type in mdnsd_find

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -1247,7 +1247,9 @@ mdns_record_t *mdnsd_find(mdns_daemon_t *d, const char *name, unsigned short typ
 		const mdns_answer_t *data;
 
 		data = mdnsd_record_data(r);
-		if (data && data->type == type)
+		// Search for a record with the same type and name. Records with different names might be in the same linked list
+		// when the hash functions % SPRIME assigns them the same index (hash collision)
+		if (data->type == type && strcmp(data->name, name) == 0)
 			return r;
 
 		r = mdnsd_record_next(r);


### PR DESCRIPTION
 - Otherwise, records with names creating the same hash % SPRIME won't
	be added when they first added record with the requested type
	was already created before

 - furthermore: The check for "data" is always true. We need to check r
	which is checked before in the while condition