### PR TITLE
Avoid strcmp with NULL pointers in _a_match

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -186,8 +186,8 @@ static int _a_match(struct resource *r, mdns_answer_t *a)
 	if (strcmp(r->name, a->name) || r->type != a->type)
 		return 0;
 
-	if (r->type == QTYPE_SRV && !strcmp(r->known.srv.name, a->rdname) && a->srv.port == r->known.srv.port &&
-	    a->srv.weight == r->known.srv.weight && a->srv.priority == r->known.srv.priority)
+	if (r->type == QTYPE_SRV && r->known.srv.name && a->rdname && !strcmp(r->known.srv.name, a->rdname) &&
+		a->srv.port == r->known.srv.port && a->srv.weight == r->known.srv.weight && a->srv.priority == r->known.srv.priority)
 		return 1;
 
 	if ((r->type == QTYPE_PTR || r->type == QTYPE_NS || r->type == QTYPE_CNAME) && !strcmp(a->rdname, r->known.ns.name))


### PR DESCRIPTION
Hey!
In some circumstances, the strings to compare in _a_match are NULL pointers. In order to avoid the application to crash, I added a check to confirm the validity of the string pointers.


Best Regards
Thomas
