### PR TITLE
Fix fuzzer findings

### DIFF
--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -104,12 +104,14 @@ static void _label(struct message *m, unsigned char **bufp, char **namep)
 	/* Loop storing label in the block */
 	for (label = (char *)*bufp; *label != 0; name += *label + 1, label += *label + 1) {
 		/* Skip past any compression pointers, kick out if end encountered (bad data prolly) */
+		int prevOffset = -1;
 		while (*label & 0xc0) {
 			unsigned short int offset = _ldecomp(label);
-			if (offset > m->_len)
+			if (offset <= prevOffset || offset > m->_len)
 				return;
 			if (*(label = (char *)m->_buf + offset) == 0)
 				break;
+			prevOffset = offset;
 		}
 
 		/* Make sure we're not over the limits */

--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -255,8 +255,10 @@ static int _rrparse(struct message *m, struct resource *rr, int count, unsigned 
 //		fprintf(stderr, "Record type %d class 0x%2x ttl %lu len %d\n", rr[i].type, rr[i].class, rr[i].ttl, rr[i].rdlength);
 
 		/* If not going to overflow, make copy of source rdata */
-		if (rr[i].rdlength + (*bufp - m->_buf) > MAX_PACKET_LEN || m->_len + rr[i].rdlength > MAX_PACKET_LEN)
+		if (rr[i].rdlength + (*bufp - m->_buf) > MAX_PACKET_LEN || m->_len + rr[i].rdlength > MAX_PACKET_LEN) {
+			rr[i].rdlength = 0;
 			return 1;
+		}
 
 		/* For the following records the rdata will be parsed later. So don't set it here:
 		 * NS, CNAME, PTR, DNAME, SOA, MX, AFSDB, RT, KX, RP, PX, SRV, NSEC

--- a/libmdnsd/1035.h
+++ b/libmdnsd/1035.h
@@ -116,8 +116,9 @@ void long2net (unsigned long int  l, unsigned char **buf);
 /**
  * parse packet into message, packet must be at least MAX_PACKET_LEN and
  * message must be zero'd for safety
+ * @returns 0 if OK, else parser error.
  */
-void message_parse(struct message *m, unsigned char *packet);
+int message_parse(struct message *m, unsigned char *packet);
 
 /**
  * create a message for sending out on the wire

--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -1351,7 +1351,9 @@ static int process_in(mdns_daemon_t *d, int sd)
 		buf[MAX_PACKET_LEN] = 0;
 		mdnsd_log_hex("Got Data:", buf, bsize);
 
-		message_parse(&m, buf);
+		rc = message_parse(&m, buf);
+		if (rc)
+			return 1;
 		rc = mdnsd_in(d, &m, from.sin_addr, ntohs(from.sin_port));
 		if (rc)
 			return 1;

--- a/src/mquery.c
+++ b/src/mquery.c
@@ -170,8 +170,9 @@ int main(int argc, char *argv[])
 			ssize = sizeof(struct sockaddr_in);
 			while ((bsize = recvfrom(sd, buf, MAX_PACKET_LEN, 0, (struct sockaddr *)&from, &ssize)) > 0) {
 				memset(&m, 0, sizeof(struct message));
-				message_parse(&m, buf);
-				mdnsd_in(d, &m, from.sin_addr, from.sin_port);
+				if (message_parse(&m, buf)==0) {
+					mdnsd_in(d, &m, from.sin_addr, from.sin_port);
+				}
 			}
 			if (bsize < 0 && errno != EAGAIN) {
 				printf("Failed reading from socket %d: %s\n", errno, strerror(errno));


### PR DESCRIPTION
I ran the AFL fuzz tester on mDNS and found several crashes and hangs, mostly because packet parser errors were ignored and the resulting half-baked message object was processed anyway. With this PR, internal parser errors are forwarded to the caller, and the packet is skipped.