### PR TITLE
Append text field to the txt record

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -512,8 +512,11 @@ static int _cache(mdns_daemon_t *d, struct resource *r)
 	ttl = (unsigned long)d->now.tv_sec + (r->ttl / 2) + 8;
 
 	/* If entry already exists, only udpate TTL value */
-	c = _c_next(d, NULL, r->name, r->type);
-	if (c) {
+	c = NULL;
+	while ((c = _c_next(d, c, r->name, r->type))) {
+		if (r->type == QTYPE_PTR && strcmp(c->rr.rdname, r->known.ns.name)) {
+			continue;
+		}
 		c->rr.ttl = ttl;
 		return 0;
 	}

--- a/src/conf.c
+++ b/src/conf.c
@@ -199,7 +199,7 @@ static int load(mdns_daemon_t *d, char *path, char *hostname)
 
 	if (srec.cname)
 		record(d, 1, srec.cname, nlocal, QTYPE_CNAME, 120);
-	record(d, 0, NULL, hlocal, QTYPE_TXT, 4500);
+	r = record(d, 0, NULL, hlocal, QTYPE_TXT, 4500);
 
 	h = xht_new(11);
 	for (i = 0; i < srec.txt_num; i++) {


### PR DESCRIPTION
- Append text field to the TXT record instead of the A record.

- In the case of QTYPE_PTR, the name must also match.