### PR TITLE
Fix clang-tidy findings

### DIFF
--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -104,12 +104,14 @@ static void _label(struct message *m, unsigned char **bufp, char **namep)
 	/* Loop storing label in the block */
 	for (label = (char *)*bufp; *label != 0; name += *label + 1, label += *label + 1) {
 		/* Skip past any compression pointers, kick out if end encountered (bad data prolly) */
+		int prevOffset = -1;
 		while (*label & 0xc0) {
 			unsigned short int offset = _ldecomp(label);
-			if (offset > m->_len)
+			if (offset <= prevOffset || offset > m->_len)
 				return;
 			if (*(label = (char *)m->_buf + offset) == 0)
 				break;
+			prevOffset = offset;
 		}
 
 		/* Make sure we're not over the limits */

--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -317,8 +317,8 @@ static int _rrparse(struct message *m, struct resource *rr, int count, unsigned 
 #define my(x,y)					\
 	while (m->_len & 7)			\
 		m->_len++;			\
-	x = (void *)(m->_packet + m->_len);	\
-	m->_len += y;
+	(x) = (void *)(m->_packet + m->_len);	\
+	m->_len += (y);
 
 int message_parse(struct message *m, unsigned char *packet)
 {

--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -457,7 +457,7 @@ void message_rdata_srv(struct message *m, unsigned short int priority, unsigned 
 
 void message_rdata_raw(struct message *m, unsigned char *rdata, unsigned short int rdlength)
 {
-	if (((unsigned char *)m->_buf - m->_packet) + rdlength > 4096)
+	if ((m->_buf - m->_packet) + rdlength > 4096)
 		rdlength = 0;
 	short2net(rdlength, &(m->_buf));
 	memcpy(m->_buf, rdata, rdlength);
@@ -503,5 +503,5 @@ int message_packet_len(struct message *m)
 	if (m->_buf == 0)
 		return 12;
 
-	return (unsigned char *)m->_buf - m->_packet;
+	return m->_buf - m->_packet;
 }

--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -80,7 +80,7 @@ void long2net(unsigned long int l, unsigned char **bufp)
 	*bufp += 4;
 }
 
-static unsigned short int _ldecomp(char *ptr)
+static unsigned short int _ldecomp(const char *ptr)
 {
 	unsigned short int i;
 
@@ -145,7 +145,7 @@ static void _label(struct message *m, unsigned char **bufp, char **namep)
 }
 
 /* Internal label matching */
-static int _lmatch(struct message *m, char *l1, char *l2)
+static int _lmatch(const struct message *m, const char *l1, const char *l2)
 {
 	int len;
 
@@ -180,7 +180,7 @@ static int _lmatch(struct message *m, char *l1, char *l2)
 }
 
 /* Nasty, convert host into label using compression */
-static int _host(struct message *m, unsigned char **bufp, char *name)
+static int _host(const struct message *m, const unsigned char **bufp, const char *name)
 {
 	char label[256], *l;
 	int len = 0, x = 1, y = 0, last = 0;

--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -255,8 +255,10 @@ static int _rrparse(struct message *m, struct resource *rr, int count, unsigned 
 //		fprintf(stderr, "Record type %d class 0x%2x ttl %lu len %d\n", rr[i].type, rr[i].class, rr[i].ttl, rr[i].rdlength);
 
 		/* If not going to overflow, make copy of source rdata */
-		if (rr[i].rdlength + (*bufp - m->_buf) > MAX_PACKET_LEN || m->_len + rr[i].rdlength > MAX_PACKET_LEN)
+		if (rr[i].rdlength + (*bufp - m->_buf) > MAX_PACKET_LEN || m->_len + rr[i].rdlength > MAX_PACKET_LEN) {
+			rr[i].rdlength = 0;
 			return 1;
+		}
 
 		/* For the following records the rdata will be parsed later. So don't set it here:
 		 * NS, CNAME, PTR, DNAME, SOA, MX, AFSDB, RT, KX, RP, PX, SRV, NSEC

--- a/libmdnsd/1035.h
+++ b/libmdnsd/1035.h
@@ -116,8 +116,9 @@ void long2net (unsigned long int  l, unsigned char **buf);
 /**
  * parse packet into message, packet must be at least MAX_PACKET_LEN and
  * message must be zero'd for safety
+ * @returns 0 if OK, else parser error.
  */
-void message_parse(struct message *m, unsigned char *packet);
+int message_parse(struct message *m, unsigned char *packet);
 
 /**
  * create a message for sending out on the wire

--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -1351,7 +1351,9 @@ static int process_in(mdns_daemon_t *d, int sd)
 		buf[MAX_PACKET_LEN] = 0;
 		mdnsd_log_hex("Got Data:", buf, bsize);
 
-		message_parse(&m, buf);
+		rc = message_parse(&m, buf);
+		if (rc)
+			return 1;
 		rc = mdnsd_in(d, &m, from.sin_addr, ntohs(from.sin_port));
 		if (rc)
 			return 1;

--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -512,8 +512,11 @@ static int _cache(mdns_daemon_t *d, struct resource *r)
 	ttl = (unsigned long)d->now.tv_sec + (r->ttl / 2) + 8;
 
 	/* If entry already exists, only udpate TTL value */
-	c = _c_next(d, NULL, r->name, r->type);
-	if (c) {
+	c = NULL;
+	while ((c = _c_next(d, c, r->name, r->type))) {
+		if (r->type == QTYPE_PTR && strcmp(c->rr.rdname, r->known.ns.name)) {
+			continue;
+		}
 		c->rr.ttl = ttl;
 		return 0;
 	}

--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -995,7 +995,7 @@ int mdnsd_out(mdns_daemon_t *d, struct message *m, struct in_addr *ip, unsigned 
 
 				if (d->probing == r)
 					d->probing = r->list;
-				else
+				else if (last)
 					last->list = r->list;
 
 				r->list = 0;
@@ -1014,7 +1014,7 @@ int mdnsd_out(mdns_daemon_t *d, struct message *m, struct in_addr *ip, unsigned 
 		}
 
 		/* Scan probe list again to append our to-be answers */
-		for (r = d->probing; r != 0; last = r, r = r->list) {
+		for (r = d->probing; r != 0; r = r->list) {
 			r->unique++;
 
 			INFO("Send Answer in Probe: Name: %s, Type: %d", r->rr.name, r->rr.type);

--- a/libmdnsd/sdtxt.c
+++ b/libmdnsd/sdtxt.c
@@ -45,14 +45,14 @@ static int _sd2txt_len(const char *key, char *val)
 	return ret;
 }
 
-static void _sd2txt_count(xht_t *h, const char *key, void *val, void *arg)
+static void _sd2txt_count(xht_t *__attribute__((unused)) h, const char *key, void *val, void *arg)
 {
 	int *count = (int *)arg;
 
 	*count += _sd2txt_len(key, (char *)val) + 1;
 }
 
-static void _sd2txt_write(xht_t *h, const char *key, void *val, void *arg)
+static void _sd2txt_write(xht_t *__attribute__((unused)) h, const char *key, void *val, void *arg)
 {
 	unsigned char **txtp = (unsigned char **)arg;
 	char *cval = (char *)val;

--- a/src/conf.c
+++ b/src/conf.c
@@ -199,7 +199,7 @@ static int load(mdns_daemon_t *d, char *path, char *hostname)
 
 	if (srec.cname)
 		record(d, 1, srec.cname, nlocal, QTYPE_CNAME, 120);
-	record(d, 0, NULL, hlocal, QTYPE_TXT, 4500);
+	r = record(d, 0, NULL, hlocal, QTYPE_TXT, 4500);
 
 	h = xht_new(11);
 	for (i = 0; i < srec.txt_num; i++) {

--- a/src/conf.c
+++ b/src/conf.c
@@ -217,6 +217,14 @@ static int load(mdns_daemon_t *d, char *path, char *hostname)
 	mdnsd_set_raw(d, r, (char *)packet, len);
 	free(packet);
 
+	free(srec.type);
+	free(srec.name);
+	free(srec.target);
+	free(srec.cname);
+	for (i = 0; i < NELEMS(srec.txt); i++) {
+		free(srec.txt[i]);
+	}
+
 	return 0;
 }
 

--- a/src/mdnsd.h
+++ b/src/mdnsd.h
@@ -35,7 +35,7 @@
 
 /* From The Practice of Programming, by Kernighan and Pike */
 #ifndef NELEMS
-#define NELEMS(array) (sizeof(array) / sizeof(array[0]))
+#define NELEMS(array) (sizeof(array) / sizeof((array)[0]))
 #endif
 
 void mdnsd_conflict(char *name, int type, void *arg);

--- a/src/mquery.c
+++ b/src/mquery.c
@@ -170,8 +170,9 @@ int main(int argc, char *argv[])
 			ssize = sizeof(struct sockaddr_in);
 			while ((bsize = recvfrom(sd, buf, MAX_PACKET_LEN, 0, (struct sockaddr *)&from, &ssize)) > 0) {
 				memset(&m, 0, sizeof(struct message));
-				message_parse(&m, buf);
-				mdnsd_in(d, &m, from.sin_addr, from.sin_port);
+				if (message_parse(&m, buf)==0) {
+					mdnsd_in(d, &m, from.sin_addr, from.sin_port);
+				}
 			}
 			if (bsize < 0 && errno != EAGAIN) {
 				printf("Failed reading from socket %d: %s\n", errno, strerror(errno));


### PR DESCRIPTION
Minor non-functional changes to remove warnings reported by the clang-tidy-9 static checker.