### PR TITLE
Fix possible memory leak and NULL dereference

### DIFF
--- a/libmdnsd/xht.c
+++ b/libmdnsd/xht.c
@@ -130,7 +130,7 @@ static xhn_t *_xht_set(xht_t *h, const char *key, void *val, char flag)
 
 void xht_set(xht_t *h, const char *key, void *val)
 {
-	if (h == NULL || key == NULL)
+	if (h == NULL || h->zen == NULL || key == NULL)
 		return;
 	_xht_set(h, key, val, 0);
 }
@@ -139,7 +139,7 @@ void xht_store(xht_t *h, const char *key, int klen, void *val, int vlen)
 {
 	char *ckey, *cval;
 
-	if (h == NULL || key == NULL || klen == 0)
+	if (h == NULL || h->zen == NULL || key == NULL || klen == 0 || val == NULL)
 		return;
 
 	ckey = malloc(klen + 1);
@@ -156,7 +156,7 @@ void *xht_get(xht_t *h, const char *key)
 {
 	xhn_t *n;
 
-	if (h == NULL || key == NULL)
+	if (h == NULL || h->zen == NULL || key == NULL)
 		return NULL;
 
 	n = _xht_node_find(&h->zen[_xhter(key) % h->prime], key);
@@ -203,7 +203,7 @@ void xht_walk(xht_t *h, xht_walker w, void *arg)
 	int i;
 	xhn_t *n;
 
-	if (h == NULL || w == NULL)
+	if (h == NULL || h->zen == NULL || w == NULL)
 		return;
 
 	for (i = 0; i < h->prime; i++) {

--- a/src/conf.c
+++ b/src/conf.c
@@ -88,24 +88,28 @@ static void read_line(char *line, struct conf_srec *srec)
 		return;
 	}
 
-	if (match(token, "type"))
+	if (match(token, "type")) {
+		free(srec->type);
 		srec->type = strdup(arg);
-	if (match(token, "name"))
+	} else if (match(token, "name")) {
+		free(srec->name);
 		srec->name = strdup(arg);
-	if (match(token, "port")) {
+	} else if (match(token, "port")) {
 		char *end;
 		srec->port = (int)strtol(arg, &end, 10);
 		if (*end) {
 			DBG("Bad port number: %s", arg);
 			return;
 		}
-	}
-	if (match(token, "target"))
+	} else if (match(token, "target")) {
+		free(srec->target);
 		srec->target = strdup(arg);
-	if (match(token, "cname"))
+	} else if (match(token, "cname")) {
+		free(srec->cname);
 		srec->cname = strdup(arg);
-	if (match(token, "txt") && srec->txt_num < NELEMS(srec->txt))
+	} else if (match(token, "txt") && srec->txt_num < NELEMS(srec->txt)) {
 		srec->txt[srec->txt_num++] = strdup(arg);
+    }
 }
 
 static int parse(char *fn, struct conf_srec *srec)


### PR DESCRIPTION
Avoid potential memory leak when loading the config file, and potential NULL pointer dereference when processing a multicast packet. Both happen under obscure circumstances only (I think). Spotted during static analysis with clang-tidy-9.

This PR fixes the last findings we got from clang-tidy, with the exception of the one described in https://github.com/troglobit/mdnsd/issues/37.