### PR TITLE
Fix check for conflict in mdnsd_in

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -830,7 +830,7 @@ int mdnsd_in(mdns_daemon_t *d, struct message *m, struct in_addr ip, unsigned sh
 				/* probing state, check for conflicts */
 				if (r->unique && r->unique < 5 && !r->modified) {
 					/* Check all to-be answers against our own */
-					for (j = 0; j < m->nscount; j++) {
+					for (j = 0; j < m->ancount; j++) {
 						if (!m->an || m->qd[i].type != m->an[j].type || strcmp(m->qd[i].name, m->an[j].name))
 							continue;
 


### PR DESCRIPTION
To be honest, I do not really understand what this code does, or rather what it is used for. But it still looks like an error to me, when a `for` loop runs over the count of authority responses but then walks over the array of answers. Since I guess that we are actually interested in the answers here, I suggest that the for loop boundary is changed to the count of answer responses.

Since this is code from the original import, it looks like this functionality never worked (no NS records) or only by chance.