### PR TITLE
Fix parsing of A record from packet

### DIFF
--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -285,12 +285,13 @@ static int _rrparse(struct message *m, struct resource *rr, int count, unsigned 
 		/* Parse commonly known ones */
 		switch (rr[i].type) {
 		case QTYPE_A:
-			if (m->_len + 16 > MAX_PACKET_LEN)
+			if (m->_len + INET_ADDRSTRLEN > MAX_PACKET_LEN)
 				return 1;
 			rr[i].known.a.name = (char *)m->_packet + m->_len;
-			m->_len += 16;
-			sprintf(rr[i].known.a.name, "%d.%d.%d.%d", (*bufp)[0], (*bufp)[1], (*bufp)[2], (*bufp)[3]);
-			rr[i].known.a.ip.s_addr = net2long(bufp);
+			m->_len += INET_ADDRSTRLEN;
+			inet_ntop(AF_INET, *bufp, rr[i].known.a.name, INET_ADDRSTRLEN);
+			memcpy(&(rr[i].known.a.ip.s_addr), *bufp, sizeof(rr[i].known.a.ip.s_addr));
+			*bufp += sizeof(rr[i].known.a.ip.s_addr);
 			break;
 
 		case QTYPE_NS:


### PR DESCRIPTION
This is also a bug that has been long in existence. Which makes me wonder about two things. First, is the fact that the IP address is reversed in the cache expected behaviour, or is no-one using this so that it hasn't surfaced yet?

And secondly, what are the intended target systems of the library? Should it be usable on any (e.g. embedded) system, i.e. also non-POSIX systems? Because the original code did not use any network library function. This bug (I call it a bug) was introduced when switching from an `int` to an `in_addr`, which brought in the the `arpa/inet.h` header. So should I refrain from using POSIX functions like `inet_ntop`? I saw them used in `mdnsd.c` so I would think it is okay.
Because if this is code to be potentially run on more than a PC, it is rather fixed to little endian systems.

This is one of the two issues I have with these convenience functions like `net2long`. They do the conversion manually instead of using standard methods like `ntohl` etc, and are therefore only working on little endian systems. On a big endian system this will break. The other is that I personally dislike that these functions have side effects on the buffer pointer passed in without mentioning that in the function name in any way,