### PR TITLE
Send AAAA records (over IPv4)

### DIFF
--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -454,10 +454,24 @@ void message_ar(struct message *m, char *name, unsigned short int type, unsigned
 	_rrappend(m, name, type, class, ttl);
 }
 
-void message_rdata_long(struct message *m, struct in_addr l)
+void message_rdata_long(struct message *m, unsigned long l)
 {
 	short2net(4, &(m->_buf));
-	long2net(l.s_addr, &(m->_buf));
+	long2net(l, &(m->_buf));
+}
+
+void message_rdata_ipv4(struct message *m, struct in_addr a)
+{
+	short2net(4, &(m->_buf));
+	memcpy(m->_buf, &a.s_addr, 4);
+	m->_buf += 4;
+}
+
+void message_rdata_ipv6(struct message *m, struct in6_addr a6)
+{
+	short2net(16, &(m->_buf));
+	memcpy(m->_buf, a6.s6_addr, 16);
+	m->_buf += 16;
 }
 
 void message_rdata_name(struct message *m, char *name)

--- a/libmdnsd/1035.h
+++ b/libmdnsd/1035.h
@@ -146,7 +146,9 @@ void message_ar(struct message *m, char *name, unsigned short int type, unsigned
 /**
  * Append various special types of resource data blocks
  */
-void message_rdata_long (struct message *m, struct in_addr l);
+void message_rdata_long (struct message *m, unsigned long l);
+void message_rdata_ipv4 (struct message *m, struct in_addr a);
+void message_rdata_ipv6 (struct message *m, struct in6_addr a6);
 void message_rdata_name (struct message *m, char *name);
 void message_rdata_srv  (struct message *m, unsigned short int priority, unsigned short int weight,
 			 unsigned short int port, char *name);

--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -174,6 +174,8 @@ static size_t _rr_len(mdns_answer_t *rr)
 		len += strlen(rr->rdname); /* worst case */
 	if (rr->ip.s_addr)
 		len += 4;
+	if (! IN6_IS_ADDR_UNSPECIFIED(&(rr->ip6)))
+		len += 16;
 	if (rr->type == QTYPE_PTR)
 		len += 6;	/* srv record stuff */
 
@@ -613,7 +615,9 @@ static void _a_copy(struct message *m, mdns_answer_t *a)
 	}
 
 	if (a->ip.s_addr)
-		message_rdata_raw(m, (unsigned char *)&a->ip, 4);
+		message_rdata_ipv4(m, a->ip);
+	else if (!IN6_IS_ADDR_UNSPECIFIED(&(a->ip6)))
+		message_rdata_ipv6(m, a->ip6);
 	if (a->type == QTYPE_SRV)
 		message_rdata_srv(m, a->srv.priority, a->srv.weight, a->srv.port, a->rdname);
 	else if (a->rdname)
@@ -1392,6 +1396,12 @@ void mdnsd_set_host(mdns_daemon_t *d, mdns_record_t *r, const char *name)
 void mdnsd_set_ip(mdns_daemon_t *d, mdns_record_t *r, struct in_addr ip)
 {
 	r->rr.ip = ip;
+	_r_publish(d, r);
+}
+
+void mdnsd_set_ipv6(mdns_daemon_t *d, mdns_record_t *r, struct in6_addr ip6)
+{
+	r->rr.ip6 = ip6;
 	_r_publish(d, r);
 }
 

--- a/libmdnsd/mdnsd.h
+++ b/libmdnsd/mdnsd.h
@@ -239,6 +239,7 @@ void mdnsd_done(mdns_daemon_t *d, mdns_record_t *r);
 void mdnsd_set_raw(mdns_daemon_t *d, mdns_record_t *r, const char *data, unsigned short len);
 void mdnsd_set_host(mdns_daemon_t *d, mdns_record_t *r, const char *name);
 void mdnsd_set_ip(mdns_daemon_t *d, mdns_record_t *r, struct in_addr ip);
+void mdnsd_set_ipv6(mdns_daemon_t *d, mdns_record_t *r, struct in6_addr ip6);
 void mdnsd_set_srv(mdns_daemon_t *d, mdns_record_t *r, unsigned short priority, unsigned short weight, unsigned short port, char *name);
 
 /**

--- a/libmdnsd/mdnsd.h
+++ b/libmdnsd/mdnsd.h
@@ -115,6 +115,16 @@ void mdnsd_set_address(mdns_daemon_t *d, struct in_addr addr);
 struct in_addr mdnsd_get_address(mdns_daemon_t *d);
 
 /**
+ * Set mDNS daemon host IPv6 address
+ */
+void mdnsd_set_ipv6_address(mdns_daemon_t *d, struct in6_addr addr);
+
+/**
+ * Get mDNS daemon host IPv6 address from previous set
+ */
+struct in6_addr mdnsd_get_ipv6_address(mdns_daemon_t *d);
+
+/**
  * Gracefully shutdown the daemon, use mdnsd_out() to get the last
  * packets
  */

--- a/src/conf.c
+++ b/src/conf.c
@@ -213,6 +213,13 @@ static int load(struct iface *iface, char *path, char *hostname)
 		mdnsd_set_ip(d, r, ipv4addr);
 	}
 
+	/* If an IPv6 address is already set, add an AAAA record for it. */
+	struct in6_addr ipv6addr = mdnsd_get_ipv6_address(d);
+	if (!IN6_IS_ADDR_UNSPECIFIED(&ipv6addr)) {
+		r = record(iface, 0, NULL, nlocal, QTYPE_AAAA, 120);
+		mdnsd_set_ipv6(d, r, ipv6addr);
+	}
+
 	if (srec.cname)
 		record(iface, 1, srec.cname, nlocal, QTYPE_CNAME, 120);
 	r = record(iface, 0, NULL, hlocal, QTYPE_TXT, 4500);

--- a/src/conf.c
+++ b/src/conf.c
@@ -206,8 +206,12 @@ static int load(struct iface *iface, char *path, char *hostname)
 	r = record(iface, 0, NULL, hlocal, QTYPE_SRV, 120);
 	mdnsd_set_srv(d, r, 0, 0, srec.port, nlocal);
 
-	r = record(iface, 0, NULL, nlocal, QTYPE_A, 120);
-	mdnsd_set_ip(d, r, mdnsd_get_address(d));
+	/* If an IPv4 address is already set, add an A record for it. */
+	struct in_addr ipv4addr = mdnsd_get_address(d);
+	if (ipv4addr.s_addr != 0) {
+		r = record(iface, 0, NULL, nlocal, QTYPE_A, 120);
+		mdnsd_set_ip(d, r, ipv4addr);
+	}
 
 	if (srec.cname)
 		record(iface, 1, srec.cname, nlocal, QTYPE_CNAME, 120);

--- a/src/mdnsd.c
+++ b/src/mdnsd.c
@@ -137,6 +137,7 @@ static void setup_iface(struct iface *iface)
 			exit(1);
 		}
 
+		mdnsd_set_address(iface->mdns, iface->inaddr);
 		conf_init(iface, path, hostnm);
 		mdnsd_register_receive_callback(iface->mdns, record_received, NULL);
 	}

--- a/src/mdnsd.c
+++ b/src/mdnsd.c
@@ -138,6 +138,7 @@ static void setup_iface(struct iface *iface)
 		}
 
 		mdnsd_set_address(iface->mdns, iface->inaddr);
+		mdnsd_set_ipv6_address(iface->mdns, iface->in6addr);
 		conf_init(iface, path, hostnm);
 		mdnsd_register_receive_callback(iface->mdns, record_received, NULL);
 	}
@@ -151,6 +152,7 @@ static void setup_iface(struct iface *iface)
 	}
 
 	mdnsd_set_address(iface->mdns, iface->inaddr);
+	mdnsd_set_ipv6_address(iface->mdns, iface->in6addr);
 	iface->changed = 0;
 }
 

--- a/src/mdnsd.h
+++ b/src/mdnsd.h
@@ -62,13 +62,16 @@ struct iface {
 	char               changed;
 
 	char               ifname[IFNAMSIZ];
-	int                ifindex;		/* Physical interface index   */
-	struct in_addr     inaddr;		/* == 0 for non IP interfaces */
+	int                ifindex;          /* Physical interface index   */
+	struct in_addr     inaddr;           /* == 0 for non IP interfaces */
 	struct in_addr     inaddr_old;
+	struct in6_addr    in6addr;          /* == :: for non IP interfaces */
+	struct in6_addr    in6addr_old;
+
 	int                sd;
 
 	mdns_daemon_t     *mdns;
-	int                hostid;              /* init to 1, +1 on conflict  */
+	int                hostid;           /* init to 1, +1 on conflict  */
 };
 
 void mdnsd_conflict(char *name, int type, void *arg);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,4 +5,4 @@ SUBDIRS            = src
 TEST_EXTENSIONS    = .sh
 TESTS_ENVIRONMENT  = unshare -mrun
 
-TESTS              = discover.sh
+TESTS              = discover.sh iprecords.sh

--- a/test/iprecords.sh
+++ b/test/iprecords.sh
@@ -14,5 +14,23 @@ mquery -s -t 1 test.local. >"$DIR/result" || FAIL "Not found"
 # shellcheck disable=SC2154
 grep -q "A test.local. .* $server_addr" "$DIR/result" || FAIL
 
+mdnsd_stop
+
+
+print "Adding IPv6 address to topology ..."
+nsenter --net="$server" -- ip -6 addr add "${server_addr_6}"/64 dev eth0
+mdnsd
+
+
+print "Starting mquery to query for A records ..."
+mquery -s -t 1 test.local. >"$DIR/result" || FAIL "Not found"
+# shellcheck disable=SC2154
+grep -q "A test.local. .* $server_addr" "$DIR/result" || FAIL
+
+print "Starting mquery to query for AAAA records ..."
+mquery -s -t 28 test.local. >"$DIR/result" || FAIL "Not found"
+# shellcheck disable=SC2154
+grep -q "AAAA test.local. .* $server_addr_6" "$DIR/result" || FAIL
+
 
 OK

--- a/test/iprecords.sh
+++ b/test/iprecords.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Set up basic topology, start mdnsd and then use mqeuery to query for A records.
+#set -x
+
+# shellcheck source=/dev/null
+. "$(dirname "$0")/lib.sh"
+
+topo basic
+mdnsd
+
+
+print "Starting mquery to query for A records ..."
+mquery -s -t 1 test.local. >"$DIR/result" || FAIL "Not found"
+# shellcheck disable=SC2154
+grep -q "A test.local. .* $server_addr" "$DIR/result" || FAIL
+
+
+OK

--- a/test/src/addr_test.c
+++ b/test/src/addr_test.c
@@ -26,42 +26,22 @@ void __wrap_freeifaddrs(struct ifaddrs *ifa)
 
 
 struct sockaddr_in ipv4_10_0_20_1         = { AF_INET, 0, { 0x0114000a } };
-struct sockaddr_in ipv4_255_255_255_0     = { AF_INET, 0, { 0x00ffffff } };
 struct sockaddr_in ipv4_LL_169_254_100_32 = { AF_INET, 0, { 0x2064fea9 } };
+struct sockaddr_in ipv4_255_255_255_0     = { AF_INET, 0, { 0x00ffffff } };
+struct sockaddr_in ipv4_192_168_2_100     = { AF_INET, 0, { 0x6402a8c0 } };
 
-struct ifaddrs one_ifc_one_ip4 = {
-	NULL,
-	"if0c1ip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST, 
-	(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
-};
-
-
-struct ifaddrs one_ifc_global_ip4_ll_ip4[] = {
-	{
-		one_ifc_global_ip4_ll_ip4 + 1,
-		"if0Gip4LLip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST, 
-		(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
-	},
-	{
-		NULL,
-		"if0Gip4LLip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST, 
-		(struct sockaddr*)&ipv4_LL_169_254_100_32, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
-	}
-};
-
-
-struct ifaddrs one_ifc_ll_ip4_global_ip4[] = {
-	{
-		one_ifc_ll_ip4_global_ip4 + 1,
-		"if0LLip4Gip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST, 
-		(struct sockaddr*)&ipv4_LL_169_254_100_32, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
-	},
-	{
-		NULL,
-		"if0LLip4Gip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST, 
-		(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
-	}
-};
+struct sockaddr_in6 ipv6_global       = { AF_INET6, 0, 0,
+	{ 0x20,0x01, 0x0d,0xb8, 0x00,0x61, 0xfe,0x01, 0x00,0x00, 0x00,0x00, 0xca,0xfe, 0xba,0xbe}, 0 };
+struct sockaddr_in6 ipv6_unique_local = { AF_INET6, 0, 0,
+	{ 0xfc,0x00, 0x01,0xaa, 0xbb,0xcc, 0xfe,0x01, 0x00,0x00, 0x00,0x00, 0xca,0xfe, 0xba,0xbe}, 0 };
+struct sockaddr_in6 ipv6_site_local   = { AF_INET6, 0, 0,
+	{ 0xfe,0xc0, 0x51,0xac, 0xb0,0x0b, 0x52,0x01, 0x00,0x00, 0x00,0x00, 0xca,0xfe, 0xba,0xbe}, 0 };
+struct sockaddr_in6 ipv6_link_local   = { AF_INET6, 0, 0,
+	{ 0xfe,0x80, 0x11,0xac, 0xb0,0x0b, 0x52,0x01, 0x00,0x00, 0x00,0x00, 0xca,0xfe, 0xba,0xbe}, 0 };
+struct sockaddr_in6 ipv6_FF           = { AF_INET6, 0, 0,
+	{ 0xff,0xff, 0xff,0xff, 0xff,0xff, 0xff,0xff, 0x00,0x00, 0x00,0x00, 0x00,0x00, 0x00,0x00}, 0 };
+struct sockaddr_in6 ipv6_global_2      = { AF_INET6, 0, 0,
+	{ 0x20,0x01, 0x0d,0xb8, 0x00,0x00, 0xfe,0x02, 0x00,0x00, 0x00,0x00, 0xde,0xad, 0xc0,0xce}, 0 };
 
 
 
@@ -70,6 +50,9 @@ struct ifaddrs one_ifc_ll_ip4_global_ip4[] = {
  * Tests
  */
 
+/*
+ * Test behaviour when no interfaces exist.
+ */
 static void test_iface_init_no_ifc(__attribute__((__unused__)) void **state)
 {
 	will_return(__wrap_getifaddrs, NULL);
@@ -89,14 +72,15 @@ static void check_one_iface_one_global_ipv4(char* ifname)
 	struct iface *iface = iface_iterator(1);
 	assert_non_null(iface);
 
-	/* Ignoring the (undeterminable) ifindex. */
-
 	assert_int_equal(0, iface->unused);
 	assert_int_equal(1, iface->changed);
 	assert_string_equal(ifname, iface->ifname);
+	/* Ignoring the (undeterminable) ifindex. */
 
 	assert_int_equal(ipv4_10_0_20_1.sin_addr.s_addr, iface->inaddr.s_addr);
 	assert_int_equal(0x00000000, iface->inaddr_old.s_addr);
+	assert_true(IN6_IS_ADDR_UNSPECIFIED(&iface->in6addr));
+	assert_true(IN6_IS_ADDR_UNSPECIFIED(&iface->in6addr_old));
 
 	assert_int_equal(-1, iface->sd);
 	assert_null(iface->mdns);
@@ -108,16 +92,22 @@ static void check_one_iface_one_global_ipv4(char* ifname)
 }
 
 /*
- * Test behaviour when no interfaces exist.
+ * Test that one IPv4 is set.
  */
 static void test_iface_init_one_ifc_ipv4(__attribute__((__unused__)) void **state)
 {
-	will_return(__wrap_getifaddrs, &one_ifc_one_ip4);
+	struct ifaddrs addrs = {
+		NULL,
+		"if0c1ip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+		(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+	};
+
+	will_return(__wrap_getifaddrs, &addrs);
 	will_return(__wrap_getifaddrs, 0);
 
 	iface_init(NULL);
 
-	check_one_iface_one_global_ipv4(one_ifc_one_ip4.ifa_name);
+	check_one_iface_one_global_ipv4(addrs.ifa_name);
 }
 
 /*
@@ -126,12 +116,25 @@ static void test_iface_init_one_ifc_ipv4(__attribute__((__unused__)) void **stat
  */
 static void test_iface_init_one_ifc_global_ipv4_LL_ipv4(__attribute__((__unused__)) void **state)
 {
-	will_return(__wrap_getifaddrs, one_ifc_global_ip4_ll_ip4);
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0Gip4LLip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		},
+		{
+			NULL,
+			"if0Gip4LLip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_LL_169_254_100_32, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		}
+	};
+
+	will_return(__wrap_getifaddrs, addrs);
 	will_return(__wrap_getifaddrs, 0);
 
 	iface_init(NULL);
 
-	check_one_iface_one_global_ipv4(one_ifc_global_ip4_ll_ip4->ifa_name);
+	check_one_iface_one_global_ipv4(addrs->ifa_name);
 }
 
 /*
@@ -140,14 +143,344 @@ static void test_iface_init_one_ifc_global_ipv4_LL_ipv4(__attribute__((__unused_
  */
 static void test_iface_init_one_ifc_LL_ipv4_global_ipv4(__attribute__((__unused__)) void **state)
 {
-	will_return(__wrap_getifaddrs, one_ifc_ll_ip4_global_ip4);
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0LLip4Gip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_LL_169_254_100_32, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		},
+		{
+			NULL,
+			"if0LLip4Gip4", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		}
+	};
+
+	will_return(__wrap_getifaddrs, addrs);
 	will_return(__wrap_getifaddrs, 0);
 
 	iface_init(NULL);
 
-	check_one_iface_one_global_ipv4(one_ifc_ll_ip4_global_ip4->ifa_name);
+	check_one_iface_one_global_ipv4(addrs->ifa_name);
 }
 
+
+
+
+/* Helper function testing that one IPv6 is set on one interface. */
+static void check_one_iface_one_global_ipv6(char* ifname)
+{
+	struct iface *iface = iface_iterator(1);
+	assert_non_null(iface);
+
+	assert_int_equal(0, iface->unused);
+	assert_int_equal(1, iface->changed);
+	assert_string_equal(ifname, iface->ifname);
+	/* Ignoring the (undeterminable) ifindex. */
+
+	assert_int_equal(0x00000000, iface->inaddr.s_addr);
+	assert_int_equal(0x00000000, iface->inaddr_old.s_addr);
+	assert_true(IN6_ARE_ADDR_EQUAL(&ipv6_global.sin6_addr, &iface->in6addr));
+	assert_true(IN6_IS_ADDR_UNSPECIFIED(&iface->in6addr_old));
+
+	assert_int_equal(-1, iface->sd);
+	assert_null(iface->mdns);
+	assert_int_equal(1, iface->hostid);
+
+
+	iface = iface_iterator(0);
+	assert_null(iface);
+}
+
+/*
+ * Test that one IPv6 is set.
+ */
+static void test_iface_init_one_ifc_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs = {
+		NULL,
+		"if0c1ip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+		(struct sockaddr*)&ipv6_global, (struct sockaddr*)&ipv6_FF, NULL, NULL
+	};
+
+	will_return(__wrap_getifaddrs, &addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_one_global_ipv6(addrs.ifa_name);
+}
+
+/*
+ * Test that a global IPv6 address is not overwritten with a link local one.
+ * One interface, only IPv6.
+ */
+static void test_iface_init_one_ifc_global_ipv6_LL_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0Gip6LLip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_global, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			NULL,
+			"if0Gip6LLip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		}
+	};
+
+	will_return(__wrap_getifaddrs, addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_one_global_ipv6(addrs->ifa_name);
+}
+
+/*
+ * Test that a link local IPv6 address is overwritten by a global one.
+ * One interface, only IPv6.
+ */
+static void test_iface_init_one_ifc_LL_ipv6_global_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0LLip6Gip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			NULL,
+			"if0LLip6Gip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_global, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		}
+	};
+
+	will_return(__wrap_getifaddrs, addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_one_global_ipv6(addrs->ifa_name);
+}
+
+/*
+ * Test that IPv6 addresses of lower preference get overwritten by addresses with higher one.
+ * null < link local < site local < unique local < global
+ * One interface, only IPv6.
+ */
+static void test_iface_init_one_ifc_LL_SL_UL_global_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0LLSLULGip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			addrs + 2,
+			"if0LLSLULGip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_site_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			addrs + 3,
+			"if0LLSLULGip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_unique_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			NULL,
+			"if0LLSLULGip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_global, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		}
+	};
+
+	will_return(__wrap_getifaddrs, addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_one_global_ipv6(addrs->ifa_name);
+}
+
+/*
+ * Test that IPv6 addresses of higher preference do not get overwritten by addresses with lower one.
+ * null < link local < site local < unique local < global
+ * One interface, only IPv6.
+ */
+static void test_iface_init_one_ifc_global_UL_SL_LL_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0GULSLLLip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_global, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			addrs + 2,
+			"if0GULSLLLip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_unique_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			addrs + 3,
+			"if0GULSLLLip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_site_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			NULL,
+			"if0GULSLLLip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		}
+	};
+
+	will_return(__wrap_getifaddrs, addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_one_global_ipv6(addrs->ifa_name);
+}
+
+
+
+/* Helper function testing that one IPv4 and one IPv6 is set on one interface. */
+static void check_one_iface_global_ipv4_ipv6(char* ifname)
+{
+	struct iface *iface = iface_iterator(1);
+	assert_non_null(iface);
+
+	assert_int_equal(0, iface->unused);
+	assert_int_equal(1, iface->changed);
+	assert_string_equal(ifname, iface->ifname);
+	/* Ignoring the (undeterminable) ifindex. */
+
+	assert_int_equal(ipv4_10_0_20_1.sin_addr.s_addr, iface->inaddr.s_addr);
+	assert_int_equal(0x00000000, iface->inaddr_old.s_addr);
+	assert_true(IN6_ARE_ADDR_EQUAL(&ipv6_global.sin6_addr, &iface->in6addr));
+	assert_true(IN6_IS_ADDR_UNSPECIFIED(&iface->in6addr_old));
+
+	assert_int_equal(-1, iface->sd);
+	assert_null(iface->mdns);
+	assert_int_equal(1, iface->hostid);
+
+
+	iface = iface_iterator(0);
+	assert_null(iface);
+}
+
+/*
+ * Test that one IPv4 and one IPv6 is set.
+ * One interface, IPv4 and IPv6
+ */
+static void test_iface_init_one_ifc_ipv4_ll_global_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs[] = {
+		{
+			addrs +1,
+			"if0c2ip4llgip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		},
+		{
+			addrs + 2,
+			"if0c2ip4llgip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			NULL,
+			"if0c2ip4llgip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_global, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		}
+
+	};
+
+	will_return(__wrap_getifaddrs, &addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_global_ipv4_ipv6(addrs->ifa_name);
+}
+
+
+/*
+ * Test with two interfaces, IPv4 and IPv6
+ */
+static void test_iface_init_two_ifc_ipv4_ll_global_ipv6_ipv4_ipv6(__attribute__((__unused__)) void **state)
+{
+	struct ifaddrs addrs[] = {
+		{
+			addrs + 1,
+			"if0c3ip4llgip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_10_0_20_1, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		},
+		{
+			addrs + 2,
+			"if1c2ip4gip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv4_192_168_2_100, (struct sockaddr*)&ipv4_255_255_255_0, NULL, NULL
+		},
+		{
+			addrs + 3,
+			"if0c3ip4llgip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			addrs + 4,
+			"if0c3ip4llgip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_link_local, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		},
+		{
+			NULL,
+			"if1c2ip4gip6", IFF_UP | IFF_BROADCAST | IFF_MULTICAST,
+			(struct sockaddr*)&ipv6_global_2, (struct sockaddr*)&ipv6_FF, NULL, NULL
+		}
+
+	};
+
+	will_return(__wrap_getifaddrs, &addrs);
+	will_return(__wrap_getifaddrs, 0);
+
+	iface_init(NULL);
+
+	check_one_iface_global_ipv4_ipv6(addrs->ifa_name);
+	struct iface *iface = iface_iterator(1);
+	assert_non_null(iface);
+
+	assert_int_equal(0, iface->unused);
+	assert_int_equal(1, iface->changed);
+	assert_string_equal(addrs[0].ifa_name, iface->ifname);
+	/* Ignoring the (undeterminable) ifindex. */
+
+	assert_int_equal(ipv4_10_0_20_1.sin_addr.s_addr, iface->inaddr.s_addr);
+	assert_int_equal(0x00000000, iface->inaddr_old.s_addr);
+	assert_true(IN6_ARE_ADDR_EQUAL(&ipv6_global.sin6_addr, &iface->in6addr));
+	assert_true(IN6_IS_ADDR_UNSPECIFIED(&iface->in6addr_old));
+
+	assert_int_equal(-1, iface->sd);
+	assert_null(iface->mdns);
+	assert_int_equal(1, iface->hostid);
+
+
+	iface = iface_iterator(0);
+	assert_non_null(iface);
+
+	assert_int_equal(0, iface->unused);
+	assert_int_equal(1, iface->changed);
+	assert_string_equal(addrs[1].ifa_name, iface->ifname);
+	/* Ignoring the (undeterminable) ifindex. */
+
+	assert_int_equal(ipv4_192_168_2_100.sin_addr.s_addr, iface->inaddr.s_addr);
+	assert_int_equal(0x00000000, iface->inaddr_old.s_addr);
+	assert_true(IN6_ARE_ADDR_EQUAL(&ipv6_global_2.sin6_addr, &iface->in6addr));
+	assert_true(IN6_IS_ADDR_UNSPECIFIED(&iface->in6addr_old));
+
+	assert_int_equal(-1, iface->sd);
+	assert_null(iface->mdns);
+	assert_int_equal(1, iface->hostid);
+
+
+	iface = iface_iterator(0);
+	assert_null(iface);
+}
 
 
 
@@ -162,9 +495,18 @@ int main(void)
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_iface_init_no_ifc),
+
 		cmocka_unit_test_teardown(test_iface_init_one_ifc_ipv4, teardown),
 		cmocka_unit_test_teardown(test_iface_init_one_ifc_global_ipv4_LL_ipv4, teardown),
 		cmocka_unit_test_teardown(test_iface_init_one_ifc_LL_ipv4_global_ipv4, teardown),
+
+		cmocka_unit_test_teardown(test_iface_init_one_ifc_ipv6, teardown),
+		cmocka_unit_test_teardown(test_iface_init_one_ifc_global_ipv6_LL_ipv6, teardown),
+		cmocka_unit_test_teardown(test_iface_init_one_ifc_LL_ipv6_global_ipv6, teardown),
+		cmocka_unit_test_teardown(test_iface_init_one_ifc_LL_SL_UL_global_ipv6, teardown),
+		cmocka_unit_test_teardown(test_iface_init_one_ifc_global_UL_SL_LL_ipv6, teardown),
+
+		cmocka_unit_test_teardown(test_iface_init_one_ifc_ipv4_ll_global_ipv6, teardown),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This is the second step towards IPv6 (#10), with the mdnsd sending AAAA records for interfaces that have a IPv6 address assigned.

It is currently broken (unfinished), because of how the [current code creates A records](https://github.com/troglobit/mdnsd/blob/8ddec741c6a60a589b3e11803866688dc60465a4/src/conf.c#L209-L210). The A record is created unconditionally assuming that there will always be an IPv4 address. The address is set later in the record because it is not known at the time the record is created.
This poses a problem when now a AAAA record is added the same way. Because now both records are created unconditionally without knowing an IPv4/6 address. But one cannot rely on the address being added later. Because maybe there is only a IPv4 address, or maybe there is only an IPv6 address.

What adds to the problem is how the message is [put togethe](https://github.com/troglobit/mdnsd/blob/8ddec741c6a60a589b3e11803866688dc60465a4/libmdnsd/mdnsd.c#L647-L653)r. Resource records are added without the RDATA, and then the RDATA is [copied in independently](https://github.com/troglobit/mdnsd/blob/8ddec741c6a60a589b3e11803866688dc60465a4/libmdnsd/mdnsd.c#L608). This process has no idea if the RDATA is actually present and valid, which in the end leads to malformed mDNS packages that have resource records without the expected RDATA in there if an interface has only an IPv4 address but no IPv6 address assigned.

I see multiple approaches to tackle this, asking for comments.

One way would be to leave the creation of the AAAA record as it is, unconditionally in case we suddenly get an IPv6 address, and change the part how the message is put together. It needs to check if the record is valid before adding any resource record data to the message.

The second way would be to leave the message creation as is, relying on records being valid. Which means that the creation of the record needs to be changed.
One option would be to [change the order](https://github.com/troglobit/mdnsd/blob/8ddec741c6a60a589b3e11803866688dc60465a4/src/mdnsd.c#L133-L152) of reading the configuration and setting the IP addresses on `mdns`, and then only creating the record when an address is present.
The other option would be to remove the creation of A and AAAA records from `conf.c` and move the logic into the `mdnsd_set_address` [method](https://github.com/troglobit/mdnsd/blob/8ddec741c6a60a589b3e11803866688dc60465a4/libmdnsd/mdnsd.c#L687). This would mean that when an address is set, the method is responsible to make sure that an updated A/AAAA record exists, either by updating it or by creating one. Should the address be invalid (i.e. 0), then an existing record needs to be removed.

One has to keep in mind that an interface can now get an address of a family assigned that it didn't have before, or vice versa. One cannot rely on an address always being there anymore.