### PR TITLE
libmdnsd: Remove A/AAAA records when IP is set to 0

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -703,8 +703,15 @@ void mdnsd_set_address(mdns_daemon_t *d, struct in_addr addr)
 		while (r) {
 			next = r->next;
 
-			if (r->rr.type == QTYPE_A)
-				mdnsd_set_ip(d, r, addr);
+			if (r->rr.type == QTYPE_A) {
+				if (addr.s_addr == 0) {
+					r->rr.ttl = 0;
+					r->list = d->a_now;
+					d->a_now = r;
+				} else {
+					mdnsd_set_ip(d, r, addr);
+				}
+			}
 
 			r = next;
 		}
@@ -732,8 +739,15 @@ void mdnsd_set_ipv6_address(mdns_daemon_t *d, struct in6_addr addr)
 		while (r) {
 			next = r->next;
 
-			if (r->rr.type == QTYPE_AAAA)
-				mdnsd_set_ipv6(d, r, addr);
+			if (r->rr.type == QTYPE_AAAA) {
+				if (IN6_IS_ADDR_UNSPECIFIED(&addr)) {
+					r->rr.ttl = 0;
+					r->list = d->a_now;
+					d->a_now = r;
+				} else {
+					mdnsd_set_ipv6(d, r, addr);
+				}
+			}
 
 			r = next;
 		}

--- a/test/iprecords.sh
+++ b/test/iprecords.sh
@@ -33,4 +33,31 @@ mquery -s -t 28 test.local. >"$DIR/result" || FAIL "Not found"
 grep -q "AAAA test.local. .* $server_addr_6" "$DIR/result" || FAIL
 
 
+
+print "Removing all IPv6 addresses from topology while mdnsd is running..."
+nsenter --net="$server" -- ip -6 addr flush dev eth0
+collect
+print "Waiting 15 seconds for mdnsd to catch up..."
+sleep 15
+stop_collect
+
+# Check that Goodbye packets (TTL == 0) were sent
+if [ -f "$DIR/pcap" ] ; then
+	response=$(tshark -r "$DIR/pcap" -Y mdns -T fields -e dns.resp.ttl -e dns.aaaa 2>&1 | grep -v "root")
+	[ -n "$response" ] || FAIL "No mDNS goodbye packets found"
+	[ "${response}" = "0,0	${server_addr_6},${server_addr_6}" ] || FAIL "mDNS packets did not match goodbye packet requirements"
+
+fi
+
+print "Starting mquery to query for A records ..."
+mquery -s -t 1 test.local. >"$DIR/result" || FAIL "Not found"
+# shellcheck disable=SC2154
+grep -q "A test.local. .* $server_addr" "$DIR/result" || FAIL
+
+print "Starting mquery to query for AAAA records ..."
+mquery -s -t 28 test.local. >"$DIR/result" || FAIL
+# shellcheck disable=SC2154
+grep -q "AAAA test.local. " "$DIR/result" && FAIL "No AAAA records should be sent anymore"
+
+
 OK

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -64,7 +64,7 @@ mdnsd_stop()
 	print "Stopping mdnsd ..."
 	leftpids=""
 	while read pid prog; do
-		if [ "$prog" == "mdnsd" ] ; then
+		if [ x"$prog" = x"mdnsd" ] ; then
 			kill "$pid" 2>/dev/null
 		else
 			leftpids="${leftpids}$pid $prog\n"
@@ -96,6 +96,25 @@ collect()
     nsenter --net="$client" -- tshark -w "$DIR/pcap" -lni eth0 2>/dev/null &
     echo "$! tshark" >> "$DIR/pids"
     sleep 2
+}
+
+# stop all instances of the pcap collector
+stop_collect()
+{
+	[ -f "${DIR}/pids" ] || SKIP "Cannot find PID file"
+
+	print "Stopping collector ..."
+	leftpids=""
+	while read pid prog; do
+		if [ x"$prog" = x"tshark" ] ; then
+			kill "$pid" 2>/dev/null
+		else
+			leftpids="${leftpids}$pid $prog\n"
+		fi
+	done < "${DIR}/pids"
+	echo -n "${leftpids}" > "${DIR}/pids"
+
+	sleep 1
 }
 
 # Set up two logically separated network namespaces, connected via a


### PR DESCRIPTION
With multiple protocols available it can happen that an active interface gets all IPv6 or IPv4 addresses removed. In that case the responder should stop answering with A/AAAA records. Moreover, it should send a goodbye packet that invalidates the last known IP address. This is done in `mdnsd_set_ip_address` when the IP address is 0.`

The test currently only tests with IPv6 because sending over IPv6 is not yet implemented.