### PR TITLE
libmdnsd: Make SPRIME actually a prime number

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -33,7 +33,7 @@
 #include <time.h>
 #include <errno.h>
 
-#define SPRIME 108		/* Size of query/publish hashes */
+#define SPRIME 109		/* Size of query/publish hashes */
 #define LPRIME 1009		/* Size of cache hash */
 
 #define GC 86400                /* Brute force garbage cleanup


### PR DESCRIPTION
Hashing strings for hash tables usually involves a prime number. It breaks down the raw hash into one bucket and therefore defines the size of the hash table. Chosing a prime number as hash table size will greatly reduce the number of collisions.

mdnsd uses two hash table sizes, defined by `LPRIME` and `SPRIME`. While `LPRIME` is defined to 1009, which is a prime number, `SPRIME` is defined to 108 - obviously not a prime number. Since I could not find any reason for this in code or history, this commit sets the value of `SPRIME` to 109 so that it actually is a prime number. Since using prime numbers just makes sense for hash table sizes.