### PR TITLE
Test IPv6 connectivity in net namespace

### DIFF
--- a/test/iprecords.sh
+++ b/test/iprecords.sh
@@ -47,6 +47,11 @@ if [ -f "$DIR/pcap" ] ; then
 	[ -n "$response" ] || FAIL "No mDNS goodbye packets found"
 	[ "${response}" = "0,0	${server_addr_6},${server_addr_6}" ] || FAIL "mDNS packets did not match goodbye packet requirements"
 
+else
+	echo "Unable to verify goodbye packets being sent"
+	if ! command -v tshark &>/dev/null ; then
+		echo "Program tshark is not installed. Cannot collect network packets."
+	fi
 fi
 
 print "Starting mquery to query for A records ..."

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -151,11 +151,13 @@ topo_basic()
 	nsenter --net="$client" -- ip -br rout >> "$DIR/tmp"
 	awk '{print "     "$0}' "$DIR/tmp"
 
-	print "Verifying connectivity ..."
-	nsenter --net="$client" -- ping -c1 "${server_addr}" || FAIL "No connectivity"
 
 	echo "$server" >> "$DIR/mounts"
 	echo "$client" >> "$DIR/mounts"
+
+
+	print "Verifying IPv4 connectivity ..."
+	nsenter --net="$client" -- ping -c1 "${server_addr}" || FAIL "No IPv4 connectivity"
 }
 
 topo_teardown()

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -15,6 +15,8 @@ client="${DIR}/client"
 server="${DIR}/server"
 client_addr=192.168.42.101
 server_addr=192.168.42.1
+client_addr_ll6=
+server_addr_ll6=
 client_addr_6=2001:db8:0:f101::2a:65
 server_addr_6=2001:db8:0:f101::2a:1
 
@@ -123,6 +125,8 @@ stop_collect()
 # and one client (mquery)
 topo_basic()
 {
+	local sllip
+
 	touch "$server" "$client"
 
 	unshare --net="$server" -- ip link set lo up
@@ -149,12 +153,16 @@ topo_basic()
 	nsenter --net="$server" -- ip -br rout >> "$DIR/tmp"
 	echo "Server"
 	awk '{print "     "$0}' "$DIR/tmp"
+	sllip=$(grep -i "fe80" "$DIR/tmp" | sed -e 's;.*\(fe80::.*\)/64.*;\1;')
+	if [ -n "$sllip" ] ; then server_addr_ll6=$sllip ; fi
 
 	nsenter --net="$client" -- ip -br link  > "$DIR/tmp"
 	nsenter --net="$client" -- ip -br addr >> "$DIR/tmp"
 	nsenter --net="$client" -- ip -br rout >> "$DIR/tmp"
 	echo "Client"
 	awk '{print "     "$0}' "$DIR/tmp"
+	sllip=$(grep -i "fe80" "$DIR/tmp" | sed -e 's;.*\(fe80::.*\)/64.*;\1;')
+	if [ -n "$sllip" ] ; then client_addr_ll6=$sllip ; fi
 
 
 	echo "$server" >> "$DIR/mounts"

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -132,10 +132,6 @@ topo_basic()
 	nsenter --net="$server" -- ip link set eth0 multicast on
 	nsenter --net="$server" -- ip addr add "${server_addr}"/24 dev eth0
 	nsenter --net="$server" -- ip route add default via "${server_addr}"
-	nsenter --net="$server" -- ip -br link  > "$DIR/tmp"
-	nsenter --net="$server" -- ip -br addr >> "$DIR/tmp"
-	nsenter --net="$server" -- ip -br rout >> "$DIR/tmp"
-	awk '{print "     "$0}' "$DIR/tmp"
 
 	unshare --net="$client" -- ip link set lo up
 	nsenter --net="$client" -- sleep 2 &
@@ -146,9 +142,18 @@ topo_basic()
 	nsenter --net="$client" -- ip link set eth0 multicast on
 	nsenter --net="$client" -- ip addr add "${client_addr}"/24 dev eth0
 	nsenter --net="$client" -- ip route add default via "${client_addr}"
+
+
+	nsenter --net="$server" -- ip -br link  > "$DIR/tmp"
+	nsenter --net="$server" -- ip -br addr >> "$DIR/tmp"
+	nsenter --net="$server" -- ip -br rout >> "$DIR/tmp"
+	echo "Server"
+	awk '{print "     "$0}' "$DIR/tmp"
+
 	nsenter --net="$client" -- ip -br link  > "$DIR/tmp"
 	nsenter --net="$client" -- ip -br addr >> "$DIR/tmp"
 	nsenter --net="$client" -- ip -br rout >> "$DIR/tmp"
+	echo "Client"
 	awk '{print "     "$0}' "$DIR/tmp"
 
 


### PR DESCRIPTION
@troglobit , I am trying to expand the integration tests to use IPv6, too. As a first step I collect the link local IPv6 addresses of the created devices and try to test connectivity between them.

But I fail to send packets between the server and client via IPv6. I first tried with `ping6` which resulted in `ping6: fe80::94b6:2bff:fe7b:8026 : Name or service not known`, no matter what I did.
Now I tried with netcat, but again to no avail: `nc: getaddrinfo for host "fe80::ac16:fff:fe41:d72c " port 12345: Name or service not known`.

Do you have an idea what I am missing?