### PR TITLE
Fix access to freed iface

### DIFF
--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -1535,7 +1535,7 @@ int mdnsd_step(mdns_daemon_t *d, int sd, bool in, bool out, struct timeval *tv)
 	}
 
 	/* Service Enumeration/Discovery completed */
-	if (d->disco)
+	if (d && d->disco)
 		d->disco = 0;
 
 	return rc;

--- a/src/mdnsd.c
+++ b/src/mdnsd.c
@@ -128,8 +128,10 @@ static void free_iface(struct iface *iface)
 {
 	mdnsd_shutdown(iface->mdns);
 	mdnsd_free(iface->mdns);
+	iface->mdns = NULL;
 	if (iface->sd >= 0)
 		close(iface->sd);
+	iface_free(iface);
 }
 
 static void setup_iface(struct iface *iface)


### PR DESCRIPTION
Hi,

I had an issue on my system that from time to time `mdnsd` was crashing.
After debugging, I found out that the reason was because performing a `mdnsd_step` on a freed `iface` was dereferencing the `iface->mdns->disco`.

The reason I observed this on my system is because from time to time one of my network interfaces goes down and is up again after a couple of minutes.

And, when the interface went down, the following [mdnsd_step](https://github.com/troglobit/mdnsd/blob/3a804491c0cc6458e34905b9bcaafee37ca79b19/src/mdnsd.c#L373) returned an error that then calls `free_iface(iface)`.

When this function is called, it frees the memory allocated to the `iface`, but not the `iface` itself. When not freed, this `iface` is also still present in the internal list used to store the `ifaces`, see [here](https://github.com/troglobit/mdnsd/blob/3a804491c0cc6458e34905b9bcaafee37ca79b19/src/addr.c#L43).

This fix calls `iface_free`in function `free_iface`, I don't know if some renaming should be put in place here, can be a bit confusing.

One additional point I did not yet add because I wanted some feedback, is to `reload = 1;` after calling `free_iface` [here](https://github.com/troglobit/mdnsd/blob/3a804491c0cc6458e34905b9bcaafee37ca79b19/src/mdnsd.c#L385). The reason for me would be to not remove forever an interface that we only had a network issue, we therefore add it again if `reload=1`.

 PS: Not able to run the test, always get a FAIL after calling `mquery`.
 
 BTW, I run `mdnsd -n` usually on my system.