### PR TITLE
cleanups for const/static/unused/Wformat

### DIFF
--- a/libmdnsd/Makefile.am
+++ b/libmdnsd/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES      = libmdnsd.la
 
 libmdnsd_la_SOURCES  = mdnsd.c mdnsd.h log.c 1035.c 1035.h sdtxt.c sdtxt.h xht.c xht.h
-libmdnsd_la_CFLAGS   = -std=gnu99 -W -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
+libmdnsd_la_CFLAGS   = -std=gnu99 -W -Wall -Wextra
 libmdnsd_la_CPPFLAGS = -D_GNU_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE
 libmdnsd_la_LDFLAGS  = $(AM_LDFLAGS) -version-info 1:0:0

--- a/libmdnsd/log.c
+++ b/libmdnsd/log.c
@@ -36,6 +36,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include "mdnsd.h"
 
 #ifndef MAX
 #define MAX(x,y) ((x) > (y) ? (x) : (y))
@@ -100,7 +101,7 @@ void mdnsd_log_open(const char *ident)
 	do_syslog = 1;
 }
 
-void mdnsd_log_hex(char *msg, unsigned char *buffer, ssize_t len)
+void mdnsd_log_hex(const char *msg, unsigned char *buffer, ssize_t len)
 {
 	char ascii[17];
 	int i;

--- a/libmdnsd/mdnsd.h
+++ b/libmdnsd/mdnsd.h
@@ -91,7 +91,7 @@ void mdnsd_log_time(struct timeval *tv, char *buf, size_t len);
 /**
  * HEX dump a buffer to log
  */
-void mdnsd_log_hex(char *msg, unsigned char *buffer, ssize_t len);
+void mdnsd_log_hex(const char *msg, unsigned char *buffer, ssize_t len);
 
 /**
  * Log to syslog or stdio

--- a/libmdnsd/sdtxt.c
+++ b/libmdnsd/sdtxt.c
@@ -45,14 +45,14 @@ static size_t _sd2txt_len(const char *key, char *val)
 	return ret;
 }
 
-static void _sd2txt_count(xht_t *__attribute__((unused)) h, const char *key, void *val, void *arg)
+static void _sd2txt_count(xht_t *h __attribute__((unused)), const char *key, void *val, void *arg)
 {
 	int *const count = arg;
 
 	*count += (int)_sd2txt_len(key, val) + 1;
 }
 
-static void _sd2txt_write(xht_t *__attribute__((unused)) h, const char *key, void *val, void *arg)
+static void _sd2txt_write(xht_t *h __attribute__((unused)), const char *key, void *val, void *arg)
 {
 	unsigned char **txtp = arg;
 	char *const cval = val;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS        = subdir-objects
-AM_CFLAGS               = -std=gnu99 -W -Wall -Wextra -Wno-unused-parameter
+AM_CFLAGS               = -std=gnu99 -W -Wall -Wextra
 AM_CPPFLAGS             = -D_GNU_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE
 AM_CPPFLAGS            += -I$(top_srcdir) -D_PIDFILEDIR=\"@runstatedir@\"
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -68,7 +68,7 @@ static char *chomp(char *str)
 	return str;
 }
 
-static int match(char *key, char *token)
+static int match(const char *key, const char *token)
 {
 	return !strcmp(key, token);
 }
@@ -113,7 +113,7 @@ static void read_line(char *line, struct conf_srec *srec)
     }
 }
 
-static int parse(char *fn, struct conf_srec *srec)
+static int parse(const char *fn, struct conf_srec *srec)
 {
 	FILE *fp;
 	char line[256];
@@ -132,7 +132,7 @@ static int parse(char *fn, struct conf_srec *srec)
 }
 
 /* Create a new record, or update an existing one */
-mdns_record_t *record(struct iface *iface, int shared, char *host,
+static mdns_record_t *record(struct iface *iface, int shared, char *host,
 		      const char *name, unsigned short type, unsigned long ttl)
 {
 	mdns_daemon_t *d = iface->mdns;
@@ -172,7 +172,7 @@ mdns_record_t *record(struct iface *iface, int shared, char *host,
 	return r;
 }
 
-static int load(struct iface *iface, char *path, char *hostname)
+static int load(struct iface *iface, const char *path, const char *hostname)
 {
 	mdns_daemon_t *d = iface->mdns;
 	struct conf_srec srec;
@@ -251,7 +251,7 @@ static int load(struct iface *iface, char *path, char *hostname)
 	return 0;
 }
 
-int conf_init(struct iface *iface, char *path, char *hostnm)
+int conf_init(struct iface *iface, const char *path, const char *hostnm)
 {
 	char hostname[_POSIX_HOST_NAME_MAX];
 	int hostid = iface->hostid;

--- a/src/mdnsd.c
+++ b/src/mdnsd.c
@@ -45,17 +45,17 @@
 #include "mcsock.h"
 #include "mdnsd.h"
 
-#define SYS_INTERVAL 10		/* System inteface poll interval */
+#define SYS_INTERVAL 10		/* System interface poll interval */
 
-volatile sig_atomic_t running = 1;
-volatile sig_atomic_t reload = 0;
-char *prognm      = PACKAGE_NAME;
+static volatile sig_atomic_t running = 1;
+static volatile sig_atomic_t reload = 0;
+static const char *prognm      = PACKAGE_NAME;
 char *hostnm      = NULL;
-char *ifname      = NULL;
-char *path        = NULL;
-int   background  = 1;
-int   logging     = 1;
-int   ttl         = 255;
+static char *ifname      = NULL;
+static const char *path        = NULL;
+static int   background  = 1;
+static int   logging     = 1;
+static int   ttl         = 255;
 
 
 /*
@@ -82,7 +82,7 @@ void mdnsd_conflict(char *name, int type, void *arg)
 	}
 }
 
-static void record_received(const struct resource *r, void *data)
+static void record_received(const struct resource *r, void *data __attribute__((unused)))
 {
 	char ipinput[INET6_ADDRSTRLEN];
 
@@ -200,12 +200,12 @@ static void sys_init(void)
 		setup_iface(iface);
 }
 
-static void done(int signo)
+static void done(int signo __attribute__((unused)))
 {
 	running = 0;
 }
 
-static void reconf(int signo)
+static void reconf(int signo __attribute__((unused)))
 {
 	reload = 1;
 }

--- a/src/mdnsd.h
+++ b/src/mdnsd.h
@@ -85,7 +85,7 @@ void          iface_init(char *ifname);
 void          iface_exit(void);
 
 /* conf.c */
-int conf_init(struct iface *iface, char *path, char *hostnm);
+int conf_init(struct iface *iface, const char *path, const char *hostnm);
 
 /* replacement functions for systems that don't have them  */
 #ifndef HAVE_PIDFILE

--- a/src/mquery.c
+++ b/src/mquery.c
@@ -46,9 +46,8 @@
 #include "mcsock.h"
 
 
-char *prognm = "mquery";
-mdns_daemon_t *d;
-int simple;
+static mdns_daemon_t *d;
+static int simple;
 
 
 #ifndef HAVE_STRLCPY
@@ -70,7 +69,7 @@ static char *getifname(char *ifname, size_t len)
 	while (fgets(buf, sizeof(buf), fp) != NULL) {
 		int rc, flags, cnt, use, metric, mtu, win, irtt;
 
-		rc = sscanf(buf, "%16s %X %X %X %d %d %d %X %d %d %d\n",
+		rc = sscanf(buf, "%16s %X %X %d %d %d %d %X %d %d %d\n",
 			   name, &dest, &gw, &flags, &cnt, &use, &metric,
 			   &mask, &mtu, &win, &irtt);
 
@@ -217,7 +216,7 @@ int main(int argc, char *argv[])
 	unsigned char buf[MAX_PACKET_LEN];
 	char default_iface[IFNAMSIZ] = { 0 };
 	struct sockaddr_in from, to;
-	char *name = DISCO_NAME;
+	const char *name = DISCO_NAME;
 	char *ifname = NULL;
 	int type = QTYPE_PTR;	/* 12 */
 	time_t start;


### PR DESCRIPTION
cleanups to
- use static for vars/functions if possible
- use const if possible
- fix __attribute__((unused)) to correct location
- remove unused lobal vars
- fix -Wformat warning in mquery.c

Thanks a lot for mdnsd,

Florian La Roche